### PR TITLE
gemspec and minor extension to cache API

### DIFF
--- a/lib/timedcache.rb
+++ b/lib/timedcache.rb
@@ -75,6 +75,13 @@ class TimedCache
   end
   alias :set :put
 
+  # Remove an object from the cache. e.g.:
+  #   cache.del(:session_id)
+  def delete(key)
+    @store.delete(key)
+  end
+  alias :del :delete
+
   # Retrieve the object which the given +key+. If the object has expired or
   # is not present, +nil+ is returned.
   #
@@ -170,6 +177,10 @@ class TimedCache
     def get(key, timeout = @timed_cache.default_timeout, &block)
       generic_get(key, timeout, block)
     end
+
+    def delete(key)
+      @cache.delete(key)
+    end
   end
 
   class FileStore < Store #:nodoc:
@@ -196,6 +207,10 @@ class TimedCache
       else
         @cache.transaction { generic_get(key, timeout, block) }
       end
+    end
+
+    def delete(key)
+      @cache.transaction { @cache.delete(key) }
     end
   end
 

--- a/lib/timedcache.rb
+++ b/lib/timedcache.rb
@@ -73,6 +73,7 @@ class TimedCache
       @store.put(key, value, timeout) unless value.nil?
     end
   end
+  alias :set :put
 
   # Retrieve the object which the given +key+. If the object has expired or
   # is not present, +nil+ is returned.

--- a/spec/timed_cache_spec.rb
+++ b/spec/timed_cache_spec.rb
@@ -25,6 +25,15 @@ describe "Adding and retrieving objects from the cache" do
     end
   end
 
+  it "Can remove objects from the cache" do
+    @caches.each do |cache|
+      cache.put(:myobject, "This needs caching", 10)
+      cache.get(:myobject).should == "This needs caching"
+      cache.del(:myobject)
+      cache.get(:myobject).should == nil
+    end
+  end
+
   it "Cache should hold separate values for each key" do
     @caches.each do |cache|
       cache.put(:myobject, "This needs caching", 10).should == "This needs caching"

--- a/spec/timed_cache_spec.rb
+++ b/spec/timed_cache_spec.rb
@@ -19,6 +19,12 @@ describe "Adding and retrieving objects from the cache" do
     end
   end
 
+  it "Can add an object to the cache, specifying a timeout value using the set method" do
+    @caches.each do |cache|
+      cache.set(:myobject, "This needs caching", 10).should == "This needs caching"
+    end
+  end
+
   it "Cache should hold separate values for each key" do
     @caches.each do |cache|
       cache.put(:myobject, "This needs caching", 10).should == "This needs caching"

--- a/timedcache.gemspec
+++ b/timedcache.gemspec
@@ -1,0 +1,21 @@
+Gem::Specification.new do |s|
+  s.name = %q{timedcache}
+  s.version = "0.0.3"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Nicholas Dainty"]
+  s.date = %q{2009-03-29}
+  s.description = %q{TimedCache implements a cache in which you can place objects and specify a timeout value.  If you attempt to retrieve the object within the specified timeout, the object will be returned. If the timeout period has elapsed, the TimedCache will return nil.}
+  s.email = %q{}
+  s.files = Dir['**/*']
+  s.homepage = %q{http://timedcache.rubyforge.org/}
+  s.rdoc_options = ["--charset=UTF-8", "--line-numbers", "--inline-source"]
+  s.require_paths = ["lib"]
+  s.rubygems_version = %q{1.3.6}
+  s.summary = %q{TimedCache implements a cache in which you can place objects and specify a timeout value.}
+
+  if s.respond_to? :specification_version then
+    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
+    s.specification_version = 3
+  end
+end


### PR DESCRIPTION
Please consider merging these 3 commits into master.
1. Add a gemspec so that Bundler can install timedcache from github.
2. Alias :put to :set to make the API more consistent with other cache libraries.  This makes it easier to integrate into code that abstracts the cache implementation.
3. Add a :delete method so that keys can be removed from the cache.
